### PR TITLE
Use import * as caniuse instead of import caniuse for compatibility

### DIFF
--- a/lib/get-unsupported-browsers-by-feature.js
+++ b/lib/get-unsupported-browsers-by-feature.js
@@ -1,5 +1,5 @@
 // tooling
-import caniuse from 'caniuse-lite';
+import * as caniuse from 'caniuse-lite';
 
 // return a list of browsers that do not support the feature
 export default function getUnsupportedBrowsersByFeature(feature) {


### PR DESCRIPTION
Without this, bundling with webpack for the REPL doesn't work correctly. Webpack reads the `module` file for `postcss-preset-env`, and it interprets `caniuse-lite`'s CommonJS as named exports, leading to an error. This has no affect on users using `postcss-preset-env` via the usual `main` field.

I've currently hacked around this in the webpack config, but this should be fixed for plug-and-play operation.