### PR TITLE
3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to PostCSS Preset Env
 
+### 3.4.0 (March 18, 2018)
+
+- Updated: `browserslist` to v3.2.0 (minor update)
+- Updated: `postcss` to v6.0.20 (patch update)
+- Updated: `postcss-image-set-polyfill` to `@csstools/postcss-image-set-function` (hopefully temporarily)
+
 ### 3.3.0 (March 16, 2018)
 
 - Updated: `postcss-apply` to v0.9.0 (minor update)

--- a/lib/plugins-by-specification-id.js
+++ b/lib/plugins-by-specification-id.js
@@ -8,7 +8,7 @@ import postcssCustomSelectors from 'postcss-custom-selectors';
 import postcssFocusVisible from 'postcss-focus-visible';
 import postcssFontVariant from 'postcss-font-variant';
 import postcssFontFamilySystemUi from 'postcss-font-family-system-ui';
-import postcssImageSetPolyfill from 'postcss-image-set-polyfill';
+import postcssImageSetPolyfill from '@csstools/postcss-image-set-function';
 import postcssLogical from 'postcss-logical';
 import postcssNesting from 'postcss-nesting';
 import postcssReplaceOverflowWrap from 'postcss-replace-overflow-wrap';

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
+    "@csstools/postcss-image-set-function": "^1.0.0",
     "browserslist": "^3.2.0",
     "caniuse-lite": "^1.0.30000815",
     "cssdb": "^1.6.0",
@@ -43,7 +44,6 @@
     "postcss-focus-visible": "^2.0.0",
     "postcss-font-family-system-ui": "^3.0.0",
     "postcss-font-variant": "^3.0.0",
-    "postcss-image-set-polyfill": "^0.4.4",
     "postcss-initial": "^2.0.0",
     "postcss-logical": "^1.0.2",
     "postcss-media-minmax": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "browserslist": "^3.1.2",
+    "browserslist": "^3.2.0",
     "caniuse-lite": "^1.0.30000815",
     "cssdb": "^1.6.0",
-    "postcss": "^6.0.19",
+    "postcss": "^6.0.20",
     "postcss-apply": "^0.9.0",
     "postcss-attribute-case-insensitive": "^2.0.0",
     "postcss-color-hex-alpha": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-preset-env",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Convert modern CSS into something browsers understand",
   "author": "Jonathan Neal <jonathantneal@hotmail.com>",
   "license": "CC0-1.0",

--- a/package.json
+++ b/package.json
@@ -59,12 +59,12 @@
     "babel-eslint": "^8.2.2",
     "babel-preset-env": "^1.6.1",
     "echint": "^4.0.1",
-    "eslint": "^4.18.2",
+    "eslint": "^4.19.0",
     "eslint-config-dev": "^2.0.0",
     "postcss-simple-vars": "^4.1.0",
     "postcss-tape": "^2.2.0",
     "pre-commit": "^1.2.2",
-    "rollup": "^0.57.0",
+    "rollup": "^0.57.1",
     "rollup-plugin-babel": "^3.0.3"
   },
   "eslintConfig": {


### PR DESCRIPTION
- Updates `browserslist` to v3.2.0 (minor update)
- Updates `postcss` to v6.0.20 (patch update)
- Updates `postcss-image-set-polyfill` to `@csstools/postcss-image-set-function` (hopefully temporarily)

Resolves #12