### PR TITLE
remove notice

### DIFF
--- a/src/postcss.js
+++ b/src/postcss.js
@@ -98,23 +98,6 @@ export default postcss.plugin('postcss-preset-env', opts => {
 	);
 
 	return (root, result) => {
-		const majorVersion = parseInt(result.processor.version.split('.')[0]);
-		if (majorVersion > 7) {
-			console.log('');
-			console.log(`
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                                                                                 │
-│   This version of postcss-preset-env is not optimised to work with PostCSS 8.   │
-│                Please update to version 7 of PostCSS Preset Env.                │
-│                                                                                 │
-│                    If you find issues, you can report it at:                    │
-│          https://github.com/csstools/postcss-plugins/issues/new/choose          │
-│                                                                                 │
-└─────────────────────────────────────────────────────────────────────────────────┘
-			`);
-			console.log('');
-		}
-
 		// polyfills run in execution order
 		const polyfills = supportedFeatures.reduce(
 			(promise, feature) => promise.then(


### PR DESCRIPTION
This removes the notice that `postcss-preset-env` should be updated.
At this time this message served its purpose.

It created awareness that there was an urgent need to update.

Those that haven't updated either :
- really can not or do not want to update
- use another plugin that bundles `postcss-preset-env` (e.g. `precss`)
- do not know how to use their package manager

We have now also move beyond version `7.x` and the latest release is `9.2.0`.

I don't think the message is useful anymore but it does still cause noise for users and for us.